### PR TITLE
Add reserved rockets to profile page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.2.6",
-<<<<<<< HEAD
         "prop-types": "^15.8.1",
-=======
->>>>>>> origin/Development
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-redux": "^8.0.5",

--- a/src/App.css
+++ b/src/App.css
@@ -97,7 +97,6 @@
   background-color: #0290ff;
   letter-spacing: 0.5px;
   font-weight: 700;
-  font-family: "Source+Sans+Pro", serif;
   color: #fff;
   border-style: none;
   cursor: pointer;
@@ -124,4 +123,11 @@
   font-size: 12px;
   line-height: 0px;
   color: #fff;
+}
+
+.description {
+  letter-spacing: 1.9px;
+  font-family: "Inter", sans-serif, serif;
+  font-size: 15px;
+  line-height: 24px;
 }

--- a/src/components/missions/mission.css
+++ b/src/components/missions/mission.css
@@ -70,3 +70,10 @@ tr:nth-child(even) {
   height: 35px;
   width: 100px;
 }
+
+.mission-description {
+  letter-spacing: 1.9px;
+  font-family: "Inter", sans-serif, serif;
+  font-size: 15px;
+  line-height: 24px;
+}

--- a/src/components/profile/MyProfile.js
+++ b/src/components/profile/MyProfile.js
@@ -1,16 +1,31 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
+import './profile.css';
 
 const MyProfilePage = () => {
   const missionsStat = useSelector((state) => state.Missions);
+  const rocketList = useSelector((state) => state.rockets.data);
+
   return (
     <div className="myprofile-container">
       <div className="mission-container">
         <h2>My Missions</h2>
-        <ul>
+        <ul className="booked-list">
           {missionsStat.map((miss) => {
             if (miss.reserved) {
               return <li key={miss.mission_id}>{miss.mission_name}</li>;
+            }
+            return '';
+          })}
+        </ul>
+      </div>
+
+      <div className="rockets-holder">
+        <h2>My Rockets</h2>
+        <ul>
+          {rocketList.map((rocket) => {
+            if (rocket.reserved) {
+              return <li className="li-item" key={rocket.id}>{rocket.name}</li>;
             }
             return '';
           })}

--- a/src/components/profile/profile.css
+++ b/src/components/profile/profile.css
@@ -1,0 +1,31 @@
+.myprofile-container {
+  display: flex;
+  justify-content: flex-start;
+  padding: 40px;
+  gap: 40px;
+}
+
+.mission-container,
+.rockets-holder {
+  width: 50%;
+}
+
+h2 {
+  margin: 10px;
+}
+
+ul {
+  list-style-type: none;
+  padding: 0;
+  border: 1px solid #ddd;
+}
+
+ul li {
+  padding: 12px 16px;
+  border-bottom: 1px solid #ddd;
+  height: 30px;
+}
+
+ul li:last-child {
+  border-bottom: none;
+}


### PR DESCRIPTION
In this pull i completed the last phase of the project requirements:

**Project requirements**

- Render UI: My Profile section
- Compose two/three column layout and list ONLY the rockets/dragons reserved and missions joined by the user (as per design):
- Render a list of all joined missions (use filter()).
- Render a list of all reserved rockets (use filter())
- All required functionalities of the rockets page and profile page are working as expected.
- 